### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,25 @@
 name: Test and build
+
 on:
   - push
   - pull_request
+
+permissions:
+  id-token: write  # Required for OIDC token generation
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - uses: actions/checkout@v4
 
       - name: Set up Node.js
@@ -40,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.